### PR TITLE
[Memo] Try global SnackBar presenter with ProviderListener

### DIFF
--- a/lib/main_snackbar.dart
+++ b/lib/main_snackbar.dart
@@ -134,7 +134,9 @@ class SnackBarPresenter extends StatelessWidget {
       provider: messageProvider,
       onChange: (context, value) {
         if (value != null) {
-          _showMessage(context, value);
+          if (ModalRoute.of(context).isCurrent) {
+            _showMessage(context, value);
+          }
         }
       },
       child: child,

--- a/lib/main_snackbar.dart
+++ b/lib/main_snackbar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mono_kit/mono_kit.dart';
+import 'package:state_notifier/state_notifier.dart';
 
 void main() => runApp(
       const ProviderScope(
@@ -33,37 +34,39 @@ class _HomePage extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller = useProvider(_homePageProviders(index));
+    final controller = useProvider(_homePageProvider);
     final canPop = useProvider(navigatorKeyProvider).currentState.canPop();
     return Scaffold(
-      key: controller.scaffoldKey,
       appBar: AppBar(title: Text('index: $index')),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            RaisedButton(
-              child: const Text('Show SnackBar'),
-              onPressed: () => controller.showSnackBarMessage('Hey(　´･‿･｀)'),
-            ),
-            RaisedButton(
-              child: const Text('👉 Navigate to next page'),
-              onPressed: () {
-                Navigator.of(context).push<void>(
-                  MaterialPageRoute(
-                    builder: (context) => _HomePage(
-                      index: index + 1,
-                    ),
-                  ),
-                );
-              },
-            ),
-            if (canPop)
+      body: SnackBarPresenter(
+        messageProvider: snackBarMessageNotifierProvider.state,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
               RaisedButton(
-                child: const Text('👈 Pop and show SnackBar'),
-                onPressed: controller.popAndShowSnackBar,
+                child: const Text('Show SnackBar'),
+                onPressed: () => controller.showSnackBarMessage('Hey(　´･‿･｀)'),
               ),
-          ],
+              RaisedButton(
+                child: const Text('👉 Navigate to next page'),
+                onPressed: () {
+                  Navigator.of(context).push<void>(
+                    MaterialPageRoute(
+                      builder: (context) => _HomePage(
+                        index: index + 1,
+                      ),
+                    ),
+                  );
+                },
+              ),
+              if (canPop)
+                RaisedButton(
+                  child: const Text('👈 Pop and show SnackBar'),
+                  onPressed: controller.popAndShowSnackBar,
+                ),
+            ],
+          ),
         ),
       ),
       bottomNavigationBar: BottomAppBar(
@@ -82,114 +85,78 @@ class _HomePage extends HookWidget {
 
 final navigatorKeyProvider = Provider((_) => GlobalKey<NavigatorState>());
 
-final _homePageProviders =
-    Provider.autoDispose.family<_HomePageController, int>(
-  (ref, __) {
-    final controller = _HomePageController(ref);
-    ref.onDispose(controller.dispose);
-    return controller;
-  },
+final _homePageProvider = Provider<_HomePageController>(
+  (ref) => _HomePageController(ref),
 );
 
-mixin SnackBarMixin {
-  final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey();
-  SnackBarPresenter get snackBarPresenter;
-  VoidCallback _unregisterSnackBarRegistration;
-
-  @protected
-  void registerToStackBarPresenter() {
-    _unregisterSnackBarRegistration = snackBarPresenter.register(scaffoldKey);
-  }
-
-  @protected
-  void unregisterFromStackBarPresenter() {
-    _unregisterSnackBarRegistration();
-  }
-
-  @protected
-  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBarMessage(
-    String message,
-  ) {
-    return snackBarPresenter.showMessage(message);
-  }
-
-  @protected
-  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBar(
-    SnackBar snackBar,
-  ) {
-    return snackBarPresenter.show(snackBar);
-  }
-}
-
-class _HomePageController with SnackBarMixin {
-  _HomePageController(this._ref) {
-    registerToStackBarPresenter();
-  }
+class _HomePageController {
+  _HomePageController(this._ref);
 
   final ProviderReference _ref;
 
-  @override
-  SnackBarPresenter get snackBarPresenter =>
-      _ref.read(snackBarPresenterProvider);
-
   void popAndShowSnackBar() {
     _ref.read(navigatorKeyProvider).currentState.pop();
-    // Remove registration before showing SnackBar
-    unregisterFromStackBarPresenter();
     showSnackBarMessage('Came back(　´･‿･｀)');
   }
 
-  void dispose() {
-    unregisterFromStackBarPresenter();
+  void showSnackBarMessage(String message) {
+    _ref.read(snackBarMessageNotifierProvider).showSnackBarMessage(message);
   }
 }
 
-final snackBarPresenterProvider = Provider(
-  (_) => SnackBarPresenter(),
+final snackBarMessageNotifierProvider = StateNotifierProvider(
+  (_) => SnackBarMessageNotifier(),
 );
 
-class SnackBarPresenter {
-  final _scaffoldKeys = <GlobalKey<ScaffoldState>>[];
+class SnackBarMessageNotifier extends StateNotifier<String> {
+  SnackBarMessageNotifier() : super(null);
 
-  VoidCallback register(GlobalKey<ScaffoldState> scaffoldKey) {
-    assert(!_scaffoldKeys.contains(scaffoldKey));
-    _scaffoldKeys.add(scaffoldKey);
-    return () => _unregister(scaffoldKey);
+  void showSnackBarMessage(String message) {
+    if (message != null) {
+      state = message;
+    }
+  }
+}
+
+class SnackBarPresenter extends StatelessWidget {
+  const SnackBarPresenter({
+    @required this.child,
+    @required this.messageProvider,
+    Key key,
+  }) : super(key: key);
+
+  final Widget child;
+  final ProviderBase<Object, String> messageProvider;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderListener<String>(
+      provider: messageProvider,
+      onChange: (context, value) {
+        if (value != null) {
+          _showMessage(context, value);
+        }
+      },
+      child: child,
+    );
   }
 
-  void _unregister(GlobalKey<ScaffoldState> key) {
-    assert(_scaffoldKeys.last == key || !_scaffoldKeys.contains(key));
-    _scaffoldKeys.remove(key);
-  }
-
-  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showMessage(
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> _showMessage(
+    BuildContext context,
     String message,
   ) {
-    return show(
+    return _show(
+      context,
       SnackBar(
         content: Text(message),
       ),
     );
   }
 
-  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> show(
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> _show(
+    BuildContext context,
     SnackBar snackBar,
   ) {
-    if (_scaffoldKeys.isEmpty) {
-      assert(false, '_scaffoldKeys should not be empty');
-      return null;
-    }
-    // Show SnackBar by using last ScaffoldKey
-    final scaffoldState = _scaffoldKeys.last.currentState;
-    if (scaffoldState == null) {
-      assert(false, 'scaffoldState should not be null');
-      return null;
-    }
-    scaffoldState.removeCurrentSnackBar();
-    return scaffoldState.showSnackBar(snackBar);
-  }
-
-  void dispose() {
-    _scaffoldKeys.clear();
+    return Scaffold.of(context).showSnackBar(snackBar);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_state_notifier:
   tinycolor:
   nested:
-  hooks_riverpod: ^0.6.0-dev
+  hooks_riverpod: ^0.9.0
   rxdart:
   uuid:
 dev_dependencies:


### PR DESCRIPTION
## 背景
アプリ全体で SnackBar を管理して表示したい。
例えば、画面Aから画面Bへの遷移を行ったさいˆ画面によっては画面下部に配置してあるコンポーネントと被ってしまったりするので、各画面の Scaffold から表示してあげる必要がある。

先日 Riverpod に [ProviderListner](https://pub.dev/documentation/flutter_riverpod/latest/flutter_riverpod/ProviderListener-class.html) が追加されたので、組み合わせて上手く実装することができるか探ってみる。

以前に mono さんが以下で画面ごとに GlobalKey<ScaffoldKey> をスタックして束ねる方法を考案されていたが、その他の方法があるか探る意味合い。
https://github.com/mono0926/flutter_playground/blob/ffbe9d6af29127404773c6f0ae3fd12549d48b6a/lib/main_snackbar.dart

## やったこと
- メッセージ(String)を発信する StateNotifier を用意する (SnackBarMessageNotifier)
- SnackBarMessageNotifier の state に変更があった際に、ツリー上で最も近い Scaffold から SnackBar を表示する Widget を作成する (SnackBarPresenter)
- 各画面から ProviderListener を使用して、一つ SnackBarMessageNotifier の Provider を参照する 

## 結果
以下のことが起こるので、使えない。
現在アクティブではない画面で showSnackBar が呼ばれた際にはすぐに表示されず、次回にアクティブになるまでキューに溜まる。
例えば、画面A->画面B で遷移して、画面B で 画面A側の showSnackBar を3回呼ぶと、画面A への戻り遷移後 3回 SnackBar が表示される。
 
## 改善案
- snackBar 機能のみを切り出した Widget を用意する。画面の前面に表示されていない際は、SanckBar の表示の命令を無視する仕組みをいれる